### PR TITLE
Modularize usage of common options to avoid repetitions and increase reusability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,16 @@
+# Dist files
 build
 dist
 *.egg-info
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+.history/*
+
+# Python
+__pycache__/
+*.pyc

--- a/src/eessi/cli/check.py
+++ b/src/eessi/cli/check.py
@@ -1,6 +1,7 @@
 # license (SPDX): GPL-2.0-only
 #
 # authors: Kenneth Hoste (Ghent University)
+# authors: Davide Grassano (CECAM-EPFL)
 
 import os
 import re
@@ -9,7 +10,7 @@ import subprocess
 import typer
 from rich import print as rich_print
 
-from eessi.cli.help import help_callback
+from eessi.cli import common_options as copts
 
 app = typer.Typer()
 
@@ -265,14 +266,7 @@ def check_repo(repo: str):
 
 @app.command()
 def check(
-    help: bool = typer.Option(
-        None,  # default value
-        "-h",
-        "--help",
-        help="Show this message and exit.",
-        callback=help_callback,
-        is_eager=True,
-    ),
+    help: copts.HELP = None,
 ):
     """
     Check CernVM-FS setup for accessing EESSI

--- a/src/eessi/cli/common_options.py
+++ b/src/eessi/cli/common_options.py
@@ -1,0 +1,26 @@
+# license (SPDX): GPL-2.0-only
+#
+# authors: Kenneth Hoste (Ghent University)
+# authors: Davide Grassano (CECAM-EPFL)
+
+from typing import Annotated
+
+import typer
+
+from eessi.cli.help import help_callback, version_callback
+
+HELP = Annotated[bool, typer.Option(
+    "-h",
+    "--help",
+    help="Show this message and exit aaaa.",
+    callback=help_callback,
+    is_eager=True,
+)]
+
+VERSION = Annotated[bool, typer.Option(
+    "-v",
+    "--version",
+    help="Show version of eessi CLI.",
+    callback=version_callback,
+    is_eager=True,
+)]

--- a/src/eessi/cli/init.py
+++ b/src/eessi/cli/init.py
@@ -1,27 +1,21 @@
 # license (SPDX): GPL-2.0-only
 #
 # authors: Kenneth Hoste (Ghent University)
+# authors: Davide Grassano (CECAM-EPFL)
 
 import os
 import sys
 
 import typer
 
-from eessi.cli.help import help_callback
+from eessi.cli import common_options as copts
 
 app = typer.Typer()
 
 
 @app.command()
 def init(
-    help: bool = typer.Option(
-        None,  # default value
-        "-h",
-        "--help",
-        help="Show this message and exit.",
-        callback=help_callback,
-        is_eager=True,
-    ),
+    help: copts.HELP = None,
 ):
     """
     Initialize shell environment for using EESSI

--- a/src/eessi/cli/main.py
+++ b/src/eessi/cli/main.py
@@ -3,11 +3,12 @@
 # authors:
 # - Kenneth Hoste (Ghent University)
 # - Alex Domingo (Vrije Universiteit Brussel)
+# - Davide Grassano (CECAM-EPFL)
 
 import typer
 
+from eessi.cli import common_options as copts
 from eessi.cli.check import app as check_app
-from eessi.cli.help import help_callback, version_callback
 from eessi.cli.init import app as init_app
 from eessi.cli.shell import app as shell_app
 
@@ -26,22 +27,8 @@ app.add_typer(shell_app)
 
 @app.callback()
 def main(
-    help: bool = typer.Option(
-        None,  # default value
-        "-h",
-        "--help",
-        help="Show this message and exit.",
-        callback=help_callback,
-        is_eager=True,
-    ),
-    version: bool = typer.Option(
-        None,  # default value
-        "-v",
-        "--version",
-        help="Show version of eessi CLI.",
-        callback=version_callback,
-        is_eager=True,
-    ),
+    help: copts.HELP = None,
+    version: copts.VERSION = None,
 ):
     """
     Top level eessi command

--- a/src/eessi/cli/shell.py
+++ b/src/eessi/cli/shell.py
@@ -10,7 +10,7 @@ from typing import Annotated
 import typer
 from rich import print as rich_print
 
-from eessi.cli.help import help_callback
+from eessi.cli import common_options as copts
 
 app = typer.Typer()
 
@@ -27,14 +27,7 @@ def report_error(msg, exit_code: int = 1):
 
 @app.command()
 def shell(
-    help: bool = typer.Option(
-        None,  # default value
-        "-h",
-        "--help",
-        help="Show this message and exit.",
-        callback=help_callback,
-        is_eager=True,
-    ),
+    help: copts.HELP = None,
     eessi_version: Annotated[str, typer.Option(
         help="EESSI version"
     )] = '',


### PR DESCRIPTION
Currently any change to the `help` and `version` options would need to be performed manually on all sub-commands.

The proposed way makes the options re-usable to reduce code duplication and improves re-usability

Also added some more common ignored files to `.gitignore`